### PR TITLE
noticelogic plugin

### DIFF
--- a/_data/scripts.yaml
+++ b/_data/scripts.yaml
@@ -2880,6 +2880,18 @@
   sbitems: "noteserv"
   version: "2002123101"
 
+- authors: "Ben Klein, based on noticemove by Timo Sirainen"
+  changed: "2014-07-10T09:20+1000"
+  changes: "v2.0 - Rewrite noticemove to prefer active window"
+  contact: "shacklein\@gmail.com", 
+  description: "Print private notices in query/channel where you're talking to them. Prefers active window if they're there with you."
+  filename: "noticelogic.pl"
+  modified: "2014-07-09 23:20"
+  license: "Public Domain"
+  name: "notice logic"
+  url: "http://irssi.org/"
+  version: "2.0"
+
 - authors: "Timo Sirainen"
   changed: "2002-03-04T22:47+0100,"
   changes: "v1.01 - fixed infinite loop when you werent connected to server :)"

--- a/scripts/noticelogic.pl
+++ b/scripts/noticelogic.pl
@@ -1,0 +1,67 @@
+# notice logic - irssi plugin
+use strict;
+
+use Irssi;
+use vars qw($VERSION %IRSSI); 
+$VERSION = "2.0";
+%IRSSI = (
+    authors     => "Ben Klein, based on noticemove by Timo Sirainen",
+    contact     => "shacklein\@gmail.com", 
+    name        => "notice logic",
+    description => "Print private notices in query/channel where you're talking to them. Prefers active window if they're there with you.",
+    license     => "Public Domain",
+    url         => "http://irssi.org/",
+    changed     => "2014-07-10T09:20+1000",
+    changes     => "v2.0 - Rewrite noticemove to prefer active window"
+);
+
+my $insig = 0;
+
+sub sig_print_text {
+  my ($dest, $text, $stripped) = @_;
+  my $server = $dest->{server};
+  my $active = Irssi::active_win()->{active};
+  my $hit = 0;
+
+  # ignore non-notices and notices in channels
+  return if (!$server || ($dest->{level} & MSGLEVEL_NOHILIGHT) ||
+	     !($dest->{level} & MSGLEVEL_NOTICES) ||
+	     $server->ischannel($dest->{target}));
+
+  return if ($insig);
+  $insig = 1;
+
+  # Check active query/channel for sender
+  if (ref $active && (
+        ($active->{name} eq $dest->{target} && $active->{server}->{tag} eq $dest->{server}->{tag}) ||
+	($active->isa("Irssi::Channel") && $active->nick_find($dest->{target}))
+     )) {
+    Irssi::active_win()->print($text, $dest->{level});
+    Irssi::signal_stop();
+    $hit = 1;
+  } else {
+    # print the notice in a query with the sender if there is one
+    foreach my $query ($server->queries()) {
+      if ($query->{name} eq $dest->{target}) {
+        $query->print($text, $dest->{level});
+        Irssi::signal_stop();
+        $hit = 1;
+        last;
+      }
+    }
+    if (!$hit) {
+      # print the notice in the first channel the sender is joined
+      foreach my $channel ($server->channels()) {
+        if ($channel->nick_find($dest->{target})) {
+          $channel->print($text, $dest->{level});
+          Irssi::signal_stop();
+          $hit = 1;
+          last;
+        }
+      }
+    }
+  }
+  $insig = 0;
+}
+
+Irssi::signal_add('print text', 'sig_print_text');


### PR DESCRIPTION
Rewrite of noticemove by Timo Sirainen. Now it prefers the active window.
Should only affect incoming notices, not /notice sends.

Notice message destination in preference order:
- active window if the sender is involved (channel or query)
- query with the sender if open
- channel you are joined in that has the sender in (first found is used)
- irssi default
