### PR TITLE
Fix yaml parsing error introduced by the noticelogic PR

### DIFF
--- a/_data/scripts.yaml
+++ b/_data/scripts.yaml
@@ -2883,7 +2883,7 @@
 - authors: "Ben Klein, based on noticemove by Timo Sirainen"
   changed: "2014-07-10T09:20+1000"
   changes: "v2.0 - Rewrite noticemove to prefer active window"
-  contact: "shacklein\@gmail.com", 
+  contact: 'shacklein\@gmail.com'
   description: "Print private notices in query/channel where you're talking to them. Prefers active window if they're there with you."
   filename: "noticelogic.pl"
   modified: "2014-07-09 23:20"


### PR DESCRIPTION
It broke the jekyll build

I'm guessing the backslash is there for anti-spam purposes. I'm leaving it there. Using single quotes results in it not being parsed, and it's only used in scripts.dmp which is perl and is not so dumb about unexpected backslashes.
