### PR TITLE
Escape single quotes in scripts.dmp

### DIFF
--- a/scripts.dmp
+++ b/scripts.dmp
@@ -9,11 +9,11 @@ $scripts = {
 {% for script in site.data.scripts %}
 	'{{ script.filename }}' => {
 {% for attr in required_attributes %}
-		'{{ attr }}' => '{{ script[attr] }}',{% endfor %}
+		'{{ attr }}' => '{{ script[attr] | replace: "'", "\\'" }}',{% endfor %}
 
 		'last_modified' => '{{ script.modified }}',
 {% for attr in optional_attributes %}{% if script contains attr %}
-		'{{ attr }}' => '{{ script[attr] }}',{% endif %}{% endfor %}
+		'{{ attr }}' => '{{ script[attr] | replace: "'", "\\'" }}',{% endif %}{% endfor %}
 	},
 {% endfor %}
 };


### PR DESCRIPTION
Was a syntax error. Broke scriptassist

Fixes #36

(but only when using scripts.irssi.org as source, see issue #34)
