### PR TITLE
Use the Encode module in rainbow.pl

### DIFF
--- a/scripts/rainbow.pl
+++ b/scripts/rainbow.pl
@@ -35,6 +35,7 @@ $VERSION = "1.6";
 
 use Irssi;
 use Irssi::Irc;
+use Encode;
 
 # colors list
 #  0 == white


### PR DESCRIPTION
Before, I was getting:

```
12:55:46 -!- Irssi: Error in script rainbow:
12:55:46 Undefined subroutine &Encode::_utf8_on called at /home/m/.irssi/scripts/autorun/rainbow.pl line 50.
```