### PR TITLE
Normalise version info from rcsid

### DIFF
--- a/scripts/accent.pl
+++ b/scripts/accent.pl
@@ -28,7 +28,7 @@ use strict;
 use vars qw($VERSION %IRSSI);
 
 use Irssi;
-$VERSION = '$Id: accent.pl,v 1.34 2003/03/27 15:54:25 toma Exp $';
+($VERSION) = '$Id: accent.pl,v 1.34 2003/03/27 15:54:25 toma Exp $' =~ / (\d+\.\d+) /;
 %IRSSI = (
 	authors     => 'Tamas SZERB',
 	contact     => 'toma@rulez.org',

--- a/scripts/fortune.pl
+++ b/scripts/fortune.pl
@@ -32,7 +32,7 @@ use strict;
 use vars qw($VERSION %IRSSI);
 
 use Irssi;
-$VERSION = '$Id: fortune.pl,v 1.3 2004/12/17 19:39:19 eim Exp $';
+($VERSION) = '$Id: fortune.pl,v 1.3 2004/12/17 19:39:19 eim Exp $' =~ / (\d+\.\d+) /;
 %IRSSI = (
     authors     => 'Ivo Marino',
     contact     => 'eim@cpan.rg',


### PR DESCRIPTION
Some scripts have Rcs Id as version, this displays weirdly on s.i.o now