### PR TITLE
Correctly preserve non-numeric version numbers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,13 +3,13 @@ before_install:
 - sudo apt-get update -qq
 - sudo apt-get build-dep -qq irssi libperl-prereqscanner-perl libperl-critic-perl
   cpanminus
-- sudo apt-get install -qq lynx zsh apt-file libyaml-tiny-perl libtest-most-perl libgetopt-long-descriptive-perl
+- sudo apt-get install -qq lynx zsh apt-file libtest-most-perl libgetopt-long-descriptive-perl
   libwww-perl liblog-log4perl-perl libdatetime-perl libmodule-runtime-perl libparams-classify-perl
   libtime-duration-parse-perl
 - perl -V
 - wget -qO- https://raw.githubusercontent.com/miyagawa/cpanminus/master/cpanm | sudo
   perl - App::cpanminus
-- sudo cpanm -q --skip-satisfied Perl::Critic Perl::PrereqScanner PPIx::XPath
+- sudo cpanm -q --skip-satisfied YAML::Tiny Perl::Critic Perl::PrereqScanner PPIx::XPath
 - git clone -q git://github.com/irssi/irssi irssi-head
 - pushd irssi-head
 - ./autogen.sh --with-perl=module 2>/dev/null | tail -n 17


### PR DESCRIPTION
The YAML module that available in the Travis repos does not enforce
marking of numeric-looking variables as strings. When these are parsed
by the github site generator, precision is lost as they are interpreted
numerically (eg. version: 1.10 -> turns into 1.1).

Reported by Vilkku. Fixes #125

This is an issue with the new YAML autogeneration.