### PR TITLE
Set record break char to newline when loading config file in people.pl

### DIFF
--- a/scripts/people.pl
+++ b/scripts/people.pl
@@ -11,7 +11,7 @@ unless ($@) {
     import Crypt::PasswdMD5;
 }
 
-$VERSION = "1.7";
+$VERSION = "1.8";
 %IRSSI =
 (
     authors     => "Marcin 'Qrczak' Kowalczyk, Johan 'ion' Kiviniemi",
@@ -1427,6 +1427,7 @@ sub load_config() {
     %user_flags = ();
     %channel_flags = ();
     %user_channel_flags = ();
+    local $/ = "\n";
     open CONFIG, $config or return;
     while (<CONFIG>) {
         chomp;


### PR DESCRIPTION
I think another script of mine was breaking it, so people.pl couldn't
load its own config file as it thought the whole thing was one massive
line.