### PR TITLE
Localise the $/ special variable.

### DIFF
--- a/scripts/dau.pl
+++ b/scripts/dau.pl
@@ -2686,7 +2686,7 @@ sub switch_cool {
 	} elsif ($style eq 'suffixes') {
 		my $suffix;
 		if (-e $file && -r $file) {
-			$/ = "\n";
+			local $/ = "\n";
 			@ARGV = ($file);
 			srand;
 			rand($.) < 1 && ($suffix = switch_parse_special($_, $channel)) while <>;

--- a/scripts/dejunk.pl
+++ b/scripts/dejunk.pl
@@ -274,7 +274,7 @@ sub load_activity_data {
         error("Could not read dejunk activity data from $fn: $!");
         return;
     }
-    $/ = undef;
+    local $/;
     my $file_contents = <$fh>;
     eval {
         my $data = eval $file_contents;

--- a/scripts/hlbot.pl
+++ b/scripts/hlbot.pl
@@ -209,7 +209,6 @@ my $proto = getprotobyname('udp');
 my $paddr = sockaddr_in($listen_port, $iaddr);
 socket(S, PF_INET, SOCK_DGRAM, $proto)   || die "socket: $!\n";
 bind(S, $paddr)                          || die "bind: $!\n";
-$| = 1;
 
 # Set input and signals etc. irssi related stuff.
 Irssi::input_add(fileno(S), INPUT_READ, "run_bot", "");

--- a/scripts/ircgallery.pl
+++ b/scripts/ircgallery.pl
@@ -50,7 +50,7 @@ sub print_gallery {
   my $next_channels = 0;
   my $channels;
 
-  $. = "\n";
+  local $/ = "\n";
   my $f = gensym;
   if (!open($f, "<", "$cache_path/$nick")) {
     Irssi::print("Couldn't open file $cache_path/$nick: $!", MSGLEVEL_CLIENTERROR);

--- a/scripts/news.pl
+++ b/scripts/news.pl
@@ -46,8 +46,6 @@ my $news_window_name = 'news';
 my @colors = (15, 12, 03, 06, 05, 07, 14);
 my @articles = ();
 
-$| = 1;
-
 Irssi::command_bind article => sub {
 	my $usage = '/article [-s <server>] [-p <port>] [-P <password> -U <login>] [-l <group> <count>] [-a] [-L <index>] <Message-ID>';
 

--- a/scripts/xauth.pl
+++ b/scripts/xauth.pl
@@ -362,7 +362,7 @@ sub read_users() {
         # and then we read the userfile.
         # apparently Irssi resets $/, so we set it here.
 
-        $/ = "\n";
+        local $/ = "\n";
         while( my $line = <XUSERS>) {
                 if( $line !~ /^(#|\s*$)/ ) { 
                         my ($nick, $ircnet, $password) = 
@@ -435,7 +435,7 @@ sub read_chans() {
         # and then we read the channelfile.
         # apparently Irssi resets $/, so we set it here.
 
-        $/ = "\n";
+        local $/ = "\n";
         while( my $line = <NICKCHANS>) {
                 if( $line !~ /^(#|\s*$)/ ) { 
                         my ($channel, $ircnet) = 


### PR DESCRIPTION
Follow-up to #129 to fix all $/ inside the scripts archive. Also fix
dejunk to not break scripts using the assumed default. Note, other
scripts like cmpchans might still break your scripts due to the global
nature of the Perl.