### PR TITLE
Fix scriptassist broken on unload

### DIFF
--- a/scripts/scriptassist.pl
+++ b/scripts/scriptassist.pl
@@ -1088,7 +1088,7 @@ sub sig_command_script_load ($$$) {
     no strict;
     $script = $2 if $script =~ /(.*\/)?(.*?)\.pl$/;
     if ( %{ "Irssi::Script::${script}::" }) {
-	if ( &{ "Irssi::Script::${script}::pre_unload" }) {
+	if (defined &{ "Irssi::Script::${script}::pre_unload" }) {
 	    print CLIENTCRAP "%R>>%n Triggering pre_unload function of $script...";
 	    &{ "Irssi::Script::${script}::pre_unload" }();
 	}


### PR DESCRIPTION
This is a regression introduced in
c5ad61b4b0166f7cb769f23dfece2a5d4e62bd6e where one `defined' statement
got removed in error while cleaning up warnings. Fixes #134