### PR TITLE
Add version guard to trackbar

### DIFF
--- a/scripts/trackbar.pl
+++ b/scripts/trackbar.pl
@@ -123,7 +123,7 @@
 
 use strict;
 use 5.6.1;
-use Irssi;
+use Irssi 20140701;
 use Irssi::TextUI;
 use POSIX qw(strftime);
 use utf8;


### PR DESCRIPTION
Adding a small version guard will make it less likely for people to run into the --more-- bug when running old Irssi.