### PR TITLE
Cycle all channels currently connected on

### DIFF
--- a/scripts/cycleall.pl
+++ b/scripts/cycleall.pl
@@ -1,0 +1,31 @@
+use strict;
+use vars qw($VERSION %IRSSI);
+
+use Irssi qw( servers command_bind channels);
+
+$VERSION = "0.1";
+%IRSSI = (
+   authors      => "Steve Clement",
+   contact      => "steve\@localhost.lu",
+   name         => "cycleall",
+   description  => "Cycles ALL your channels on ALL your servers (excluding ^[+/!/&])",
+   license      => "MIT",
+   changed      => "Mon Jun 22 16:07:28 CEST 2015"
+);
+
+sub cycle_all_channels {
+  my ($data, $server, $channel) = @_;
+  foreach my $server (servers) {
+    Irssi::print "%GEntered%c:%n check_channels";
+    for (channels) {
+      my $chatnet = $_->{server}->{chatnet} || $_->{server}->{tag};
+        if ($_->{name} !~ m/^[\+\!\&]/ ) {
+          Irssi::print "%GCycling channel%c:%n $_->{name}";
+          $_->command("cycle");
+        }
+    }
+  }
+}
+
+Irssi::print "%GLoading%c:%n reCycle";
+Irssi::command_bind("cycleall", "cycle_all_channels");


### PR DESCRIPTION
- Will do a /cycle in ALL currently connected channels on ALL currently connected servers
- Will exclude channels starting with: &, !, +
- The need came from a Bitlbee Race-condition where bitlbee wouldn't connect fast enough and empty channels were created. (I did not find an option to delay a connect to a Server…)