### PR TITLE
Edited regex for socket_path search.

### DIFF
--- a/scripts/screen_away.pl
+++ b/scripts/screen_away.pl
@@ -104,7 +104,7 @@ if ($socket !~ /^No Sockets found/s) {
   # therefore first find the pid and use that to find the actual sessionname
   $socket_pid = substr($ENV{'STY'}, 0, index($ENV{'STY'}, '.'));
   $socket_path = $socket;
-  $socket_path =~ s/^.+\d+ Sockets? in ([^\n]+)\.\n.+$/$1/s;
+  $socket_path =~ s/^.*\d+ Sockets? in ([^\n]+)\..*$/$1/s;
   $socket_name = $socket;
   $socket_name =~ s/^.+?($socket_pid\.\S+).+$/$1/s;
   if (length($socket_path) != length($socket)) {


### PR DESCRIPTION
Loading the script on my Fedora 21 suddenly failed. It seems that the regex did not match the socket path. I believe this was in conjunction with upgrading screen to version `4.03.01`. Small changes to the regex solved it, maybe this would be usefull to others as well.

Changed .+ to .* at both sides of the line and removed newline character.