### PR TITLE
script fixes for the icrnl change in irssi

### DIFF
--- a/scripts/history_search.pl
+++ b/scripts/history_search.pl
@@ -25,7 +25,7 @@ use Irssi 20070804;
 use Irssi::TextUI;
 
 use vars qw($VERSION %IRSSI);
-$VERSION = '2.0';
+$VERSION = '2.1';
 %IRSSI = (
     authors     => 'Wouter Coekaerts',
     contact     => 'coekie@irssi.org',
@@ -33,7 +33,6 @@ $VERSION = '2.0';
     description => 'Search within your typed history as you type (like ctrl-R in bash)',
     license     => 'GPLv2 or later',
     url         => 'http://wouter.coekaerts.be/irssi/',
-    changed     => '17/01/09'
 );
 
 # is the searching enabled?
@@ -78,7 +77,7 @@ Irssi::command_bind('history_search', sub {
 Irssi::signal_add_last 'gui key pressed' => sub {
 	my ($key) = @_;
 	
-	if ($key == 10 || $key == 27) { # enter or escape
+	if ($key == 10 || $key == 13 || $key == 27) { # enter or escape
 		$enabled = 0;
 	}
 

--- a/scripts/ido_switcher.pl
+++ b/scripts/ido_switcher.pl
@@ -251,7 +251,7 @@ use Irssi::TextUI;
 use Data::Dumper;
 
 
-our $VERSION = '2.3'; # 1dc0a53a2df38e9
+our $VERSION = '2.4'; # 7c9e42560a2f4a1
 our %IRSSI   =
   (
    authors     => 'Tom Feist, Wouter Coekaerts',
@@ -260,7 +260,6 @@ our %IRSSI   =
    description => 'Select window[-items] using an ido-mode like search interface',
    license     => 'GPLv2 or later',
    url         => 'http://github.com/shabble/irssi-scripts/tree/master/ido-mode/',
-   changed     => '24/7/2010'
   );
 
 
@@ -980,7 +979,7 @@ sub handle_keypress {
         Irssi::signal_stop();
     }
 
-    if ($key == 10) {       # enter
+    if ($key == 10 || $key == 13) {       # enter
         _debug_print "selecting history and quitting";
         my $selected_win = get_window_match();
         ido_switch_select($selected_win);

--- a/scripts/per_window_prompt.pl
+++ b/scripts/per_window_prompt.pl
@@ -21,7 +21,7 @@ use Irssi 20070804;
 use Irssi::TextUI;
 
 use vars qw($VERSION %IRSSI);
-$VERSION = '1.0';
+$VERSION = '1.1';
 %IRSSI = (
     authors     => 'Wouter Coekaerts',
     contact     => 'coekie@irssi.org',
@@ -29,7 +29,6 @@ $VERSION = '1.0';
     description => 'Keeps a prompt per window',
     license     => 'GPLv2 or later',
     url         => 'http://wouter.coekaerts.be/irssi/',
-    changed     => '04/08/07'
 );
 
 my %prompts;
@@ -80,7 +79,7 @@ sub UNLOAD {
 Irssi::signal_add_first 'gui key pressed' => sub {
 	my ($key) = @_;
 	
-	if ($key == 10 && ! $in_command) {
+	if (($key == 10 || $key == 13) && ! $in_command) {
 		$win_before_command = winkey(Irssi::active_win);
 		$win_before_command_deleted = 0;
 		$in_command = 1;


### PR DESCRIPTION
- accept ^M in addition to ^J as enter key for scripts which use raw gui key pressed
  (won't solve KP_ENTER issue)