### PR TITLE
ido_switcher: Allow limited searching for #\d+ channels

### DIFF
--- a/scripts/ido_switcher.pl
+++ b/scripts/ido_switcher.pl
@@ -778,7 +778,7 @@ sub update_matches {
     }
 
     $regex_valid = 1;
-    if ($search_str =~ m/^\d+$/) {
+    if ($search_str =~ m/^\d+$/ and $search_str <= @window_cache) {
 
         @search_matches =
           grep {


### PR DESCRIPTION
[Heads up to @dequis who wrote this code]

Currently if there's a channel like e.g. #911 you can't search for it
because it goes down the codepath where we try to match window ids.

As a hack around this only go down that codepath if the number the
user enters is <= than our actual number of windows, anything higher
than that can't be matched, so we might as well try to match it as a
channel name instead.

This doesn't fix the case of e.g. trying to match a channel called #10
when you have 10 windows. I think this code should by trying different
approaches in order and falling back if either there's no matches or
too few, or better yet just doing all approaches and sorting the
resultset by a heuristic like if the query matches /^\d+$/.

But this is a minor change that's good enough for my use-case, and I
can't see how it would break anything.