### PR TITLE
FIX: start and realname declaration

### DIFF
--- a/scripts/cgrep.pl
+++ b/scripts/cgrep.pl
@@ -71,6 +71,7 @@ sub event_who_result
 
     if ($busy)
     {
+        my($start,$realname);
         if ($data =~ /^(.*):([^:]{1,})$/)
         {
             $start = $1;


### PR DESCRIPTION
$start and $realname declarations have been commented out due to a change in code. This causes a problem due to the use of "use strict" (warnings). This new declaration solves the issue.