### PR TITLE
Disable auto-correction of the search input

### DIFF
--- a/index.html
+++ b/index.html
@@ -40,7 +40,7 @@ layout: default
 	
         <hr>
 
-        <input type="search" class="light-table-filter form-control" data-table="sortable" data-name="q" placeholder="Filter" style="width: 100%">
+        <input type="search" class="light-table-filter form-control" data-table="sortable" data-name="q" placeholder="Filter" style="width: 100%" autocorrect="off" spellcheck="false">
         <table class="table table-striped table-condensed sortable">
             <thead>
                 <tr>


### PR DESCRIPTION
Auto-correction is often disruptive to searches in this field where
arbitrary strings are frequently the correct item to search for.