### PR TITLE
[go.pl] Make matching behaviour configurable

### DIFF
--- a/scripts/go.pl
+++ b/scripts/go.pl
@@ -7,8 +7,19 @@ use Irssi::Irc;
 # /script load go.pl
 # If you are in #irssi you can type /go #irssi or /go irssi or even /go ir ...
 # also try /go ir<tab> and /go  <tab> (that's two spaces)
+#
+# The following settings exist:
+#
+#   /SET go_match_case_sensitive [ON|OFF]
+#     Match window/item names sensitively (the default). Turning this off
+#     means e.g. "/go foo" would jump to a window named "Foobar", too.
+#
+#   /SET go_complete_case_sensitive [ON|OFF]
+#     When using tab-completion, match case-insensitively (the default).
+#     Turning this on means that "/go foo<tab>" will *not* suggest "Foobar".
+#
 
-$VERSION = '1.01';
+$VERSION = '1.1';
 
 %IRSSI = (
     authors     => 'nohar',
@@ -16,8 +27,15 @@ $VERSION = '1.01';
     name        => 'go to window',
     description => 'Implements /go command that activates a window given a name/partial name. It features a nice completion.',
     license     => 'GPLv2 or later',
-    changed     => '2014-10-19'
+    changed     => '2017-02-02'
 );
+
+sub _make_regexp {
+	my ($name, $ci) = @_;
+	my $re = "^#?\Q${name}\E";
+	$re = "(?i:$re)" unless $ci;
+	return $re;
+}
 
 sub signal_complete_go {
 	my ($complist, $window, $word, $linestart, $want_space) = @_;
@@ -26,11 +44,12 @@ sub signal_complete_go {
 
         return unless ($linestart =~ /^\Q${k}\Ego\b/i);
 
+	my $re = _make_regexp($word, Irssi::settings_get_bool('go_complete_case_sensitive'));
 	@$complist = ();
 	foreach my $w (Irssi::windows) {
 		my $name = $w->get_active_name();
 		if ($word ne "") {
-			if ($name =~ /\Q${word}\E/i) {
+			if ($name =~ $re) {
 				push(@$complist, $name)
 			}
 		} else {
@@ -45,9 +64,11 @@ sub cmd_go
 	my($chan,$server,$witem) = @_;
 
 	$chan =~ s/ *//g;
+	my $re = _make_regexp($chan, Irssi::settings_get_bool('go_match_case_sensitive'));
+
 	foreach my $w (Irssi::windows) {
 		my $name = $w->get_active_name();
-		if ($name =~ /^#?\Q${chan}\E/) {
+		if ($name =~ $re) {
 			$w->set_active();
 			return;
 		}
@@ -56,4 +77,11 @@ sub cmd_go
 
 Irssi::command_bind("go", "cmd_go");
 Irssi::signal_add_first('complete word', 'signal_complete_go');
+Irssi::settings_add_bool('go', 'go_match_case_sensitive', 1);
+Irssi::settings_add_bool('go', 'go_complete_case_sensitive', 0);
 
+# Changelog
+#
+# 2017-02-02  1.1  martin f. krafft <madduck@madduck.net>
+#   - made case-sensitivity of match configurable
+#

--- a/scripts/go.pl
+++ b/scripts/go.pl
@@ -14,9 +14,19 @@ use Irssi::Irc;
 #     Match window/item names sensitively (the default). Turning this off
 #     means e.g. "/go foo" would jump to a window named "Foobar", too.
 #
+#   /SET go_match_anchored [ON|OFF]
+#     Match window/names only at the start of the word (the default). Turning
+#     this off will mean that strings can match anywhere in the window/names.
+#     The leading '#' of channel names is optional either way.
+#
 #   /SET go_complete_case_sensitive [ON|OFF]
 #     When using tab-completion, match case-insensitively (the default).
 #     Turning this on means that "/go foo<tab>" will *not* suggest "Foobar".
+#
+#   /SET go_complete_anchored [ON|OFF]
+#     Match window/names only at the start of the word. The default is 'off',
+#     which causes completion to match anywhere in the window/names during
+#     completion. The leading '#' of channel names is optional either way.
 #
 
 $VERSION = '1.1';
@@ -31,9 +41,10 @@ $VERSION = '1.1';
 );
 
 sub _make_regexp {
-	my ($name, $ci) = @_;
-	my $re = "^#?\Q${name}\E";
+	my ($name, $ci, $aw) = @_;
+	my $re = "\Q${name}\E";
 	$re = "(?i:$re)" unless $ci;
+	$re = "^#?$re" if $aw;
 	return $re;
 }
 
@@ -44,7 +55,9 @@ sub signal_complete_go {
 
         return unless ($linestart =~ /^\Q${k}\Ego\b/i);
 
-	my $re = _make_regexp($word, Irssi::settings_get_bool('go_complete_case_sensitive'));
+	my $re = _make_regexp($word,
+		Irssi::settings_get_bool('go_complete_case_sensitive'),
+		Irssi::settings_get_bool('go_complete_anchored'));
 	@$complist = ();
 	foreach my $w (Irssi::windows) {
 		my $name = $w->get_active_name();
@@ -64,7 +77,9 @@ sub cmd_go
 	my($chan,$server,$witem) = @_;
 
 	$chan =~ s/ *//g;
-	my $re = _make_regexp($chan, Irssi::settings_get_bool('go_match_case_sensitive'));
+	my $re = _make_regexp($chan,
+		Irssi::settings_get_bool('go_match_case_sensitive'),
+		Irssi::settings_get_bool('go_match_anchored'));
 
 	foreach my $w (Irssi::windows) {
 		my $name = $w->get_active_name();
@@ -79,9 +94,12 @@ Irssi::command_bind("go", "cmd_go");
 Irssi::signal_add_first('complete word', 'signal_complete_go');
 Irssi::settings_add_bool('go', 'go_match_case_sensitive', 1);
 Irssi::settings_add_bool('go', 'go_complete_case_sensitive', 0);
+Irssi::settings_add_bool('go', 'go_match_anchored', 1);
+Irssi::settings_add_bool('go', 'go_complete_anchored', 0);
 
 # Changelog
 #
 # 2017-02-02  1.1  martin f. krafft <madduck@madduck.net>
 #   - made case-sensitivity of match configurable
+#   - made anchoring of search strings configurable
 #


### PR DESCRIPTION
This introduces a few settings, allowing the behaviour of `go.pl` to be configured:

- `go_match_case_sensitive` (default:true), match channel names case-sensitively
- `go_complete_case_sensitive` (default:false), complete channel names case-sensitively
- `go_match_anchored` (default:true), match channel names only at start of word
- `go_complete_anchored` (default:true), complete channel names anchored at start of word

Signed-off-by: martin f. krafft <madduck@madduck.net>