### PR TITLE
Merge chanact upstream by serialising history

### DIFF
--- a/scripts/chanact.pl
+++ b/scripts/chanact.pl
@@ -39,11 +39,11 @@ $VERSION = "master";
 # Bazerka             base patch for sorting by level change
 #                     updated documentation
 # tslocum@gmail.com   Case-insensitive aliases, bugfix
-# 
+#
 #########
 # USAGE
 ###
-# 
+#
 # copy the script to ~/.irssi/scripts/
 #
 # In irssi:
@@ -104,11 +104,11 @@ $VERSION = "master";
 #		    $H : Start highlightning
 #		    $S : Stop highlightning
 #		* example:
-#		
+#
 #		      /set chanact_display $H$N:$M.$S$C
-#		      
+#
 #		    will give you on #irssi.de if you have voice
-#		    
+#
 #		      [3:+.#irssi.de]
 #
 #		    with '3:+.' highlighted and the channel name printed in regular color
@@ -122,7 +122,7 @@ $VERSION = "master";
 # /set chanact_display_alias <string>
 #   as 'chanact_display' but is used if the window has an alias and
 #   'chanact_show_alias' is set to on.
-# 
+#
 # /set chanact_show_names <ON|OFF>
 #		* ON  : show the channelnames after the number/alias
 #		* OFF : don't show the names
@@ -145,7 +145,7 @@ $VERSION = "master";
 #
 # /set chanact_autorenumber <ON|OFF>
 #		* ON  : Move the window automatically to first available slot
-#		        starting from "chanact_renumber_start" when assigning 
+#		        starting from "chanact_renumber_start" when assigning
 #		        an alias to window. Also moves the window back to a
 #		        first available slot from refnum 1 when the window
 #		        loses it's alias.
@@ -164,7 +164,7 @@ $VERSION = "master";
 # 		             beginning of the channel name.
 # 		* example  :
 # 		    To shorten a lot of debian channels:
-# 		    
+#
 # 			/set chanact_remove_prefix deb(ian.(devel-)?)?
 #
 # /set chanact_filter <int>
@@ -178,7 +178,7 @@ $VERSION = "master";
 #		* <string> : space-separated list of windows for which to use
 #			     chanact_filter_windowlist_level instead of
 #			     chanact_filter.
-#			     
+#
 #			     Alternatively, an entry can be postfixed with
 #			     a comma (',') and the level to use for that
 #			     window.
@@ -296,7 +296,7 @@ sub calculate_levels(@) {
 # this is the real creation method
 sub remake() {
 	my ($afternumber,$finish,$hilight,$mode,$number,$display,@windows);
-	my $separator = Irssi::settings_get_str('chanact_separator'); 
+	my $separator = Irssi::settings_get_str('chanact_separator');
 	my $abbrev = Irssi::settings_get_int('chanact_abbreviate_names');
 	my $remove_prefix = Irssi::settings_get_str('chanact_remove_prefix');
 	my $remove_hash = Irssi::settings_get_bool('chanact_remove_hash');
@@ -339,7 +339,7 @@ sub remake() {
 		    && $name eq "(status)") {
 			$name = "S";
 		}
-	
+
 		# check if we should show the mode
 		$mode = "";
 		if ($type eq "CHANNEL") {
@@ -351,7 +351,7 @@ sub remake() {
 
 			my $nick = $channel->nick_find($server->{nick});
 			!ref($nick) && next;
-			
+
 			if ($nick->{op}) {
 				$mode = "@";
 			} elsif ($nick->{voice}) {
@@ -382,13 +382,13 @@ sub remake() {
 			$name =~ s/^[&#+!=]//;
 		}
 
-		if (Irssi::settings_get_bool('chanact_show_alias') == 1 && 
+		if (Irssi::settings_get_bool('chanact_show_alias') == 1 &&
 				$win->{name} =~ /^([a-zA-Z+]):(.+)$/) {
 			$number = "$1";
-			$display = Irssi::settings_get_str('chanact_display_alias'); 
+			$display = Irssi::settings_get_str('chanact_display_alias');
 		} else {
 			$number = $win->{refnum};
-			$display = Irssi::settings_get_str('chanact_display'); 
+			$display = Irssi::settings_get_str('chanact_display');
 		}
 
 		# fixup { and } in nicks, those are used by irssi themes
@@ -401,7 +401,7 @@ sub remake() {
 	if ($actString ne "") {
 		# Remove the last separator
 		$actString =~ s/$separator$//;
-		
+
 		$actString = "{sb ".Irssi::settings_get_str('chanact_header').$actString."}";
 	}
 
@@ -520,7 +520,7 @@ sub cmd_window_alias {
 	cmd_window_unalias($data, $server, $witem, 1);
 
 	my $winnum = $window->{refnum};
-	
+
 	if (Irssi::settings_get_bool('chanact_autorenumber') == 1 &&
 			$window->{refnum} < $rn_start) {
 		my $old_refnum = $window->{refnum};
@@ -530,10 +530,10 @@ sub cmd_window_alias {
 		# Find the first available slot and move the window
 		while (Irssi::window_find_refnum($winnum)) { $winnum++; }
 		$window->set_refnum($winnum);
-		
+
 		Irssi::print("Moved the window from $old_refnum to $winnum");
 	}
-	
+
 	my $winserver = $window->{active_server}->{tag};
 	my $winhandle = "$winserver/$winname";
 	# cmd_window_unalias relies on a certain format here
@@ -662,10 +662,10 @@ Irssi::signal_add('nick mode changed', 'chanactHasChanged');
 #
 # 0.5.6
 # - fixed a bug (#1) reported by Wouter Coekaert
-# 
+#
 # 0.5.5
 # - some speedups from David Leadbeater <dgl@dgl.cx>
-# 
+#
 #
 # 0.5.4
 # - added help for chanact_display_alias
@@ -679,7 +679,7 @@ Irssi::signal_add('nick mode changed', 'chanactHasChanged');
 # - removed unused chanact_show_name settings (thx to Qerub)
 # - fixed $mode display
 # - guarded reference operations to (hopefully) fix errors on server disconnect
-# 
+#
 # 0.5.1
 # - small typo fixed
 #
@@ -687,7 +687,7 @@ Irssi::signal_add('nick mode changed', 'chanactHasChanged');
 # - changed chanact_show_mode to chanact_display. reversed changes from
 #   Qerub through that, but kept funcionality.
 # - removed chanact_color_all since it is no longer needed
-# 
+#
 # 0.4.3
 # - changes by Qerub
 #   + added chanact_show_mode to show the mode just before the channel name

--- a/scripts/chanact.pl
+++ b/scripts/chanact.pl
@@ -7,7 +7,7 @@ use Irssi::TextUI;
 
 use vars qw($VERSION %IRSSI);
 
-$VERSION = "master";
+$VERSION = "0.5.16";
 %IRSSI = (
     authors     => 'BC-bd',
     contact     => 'bd@bc-bd.org',
@@ -596,13 +596,19 @@ Irssi::signal_add('nick mode changed', 'chanactHasChanged');
 #
 # Changelog
 #
-# master
-# 	- fixed URL
-# 	- now with 'use warnings'
-# 	- fix cmd_window_unalias call from cmd_window_alias
-# 	- fix Use of uninitialized value $name in hash element warnings
-# 	- return from cmd_window_unalias if the window has no valid
-# 	  chanact'ified name
+# 0.5.16
+#       - fix divergence from upstream by serialising the history. The
+#         following commits are actually (Git-)historically earlier than
+#         the changes for 0.5.15, but they're being introduced to the
+#         scripts.irssi.org repo only with this 0.5.16 release, so we list
+#         them here:
+#         * fixed URL
+# 	  * now with 'use warnings'
+# 	  * fix cmd_window_unalias call from cmd_window_alias
+# 	  * fix Use of uninitialized value $name in hash element warnings
+# 	  * return from cmd_window_unalias if the window has no valid
+# 	    chanact'ified name
+# 	  (I also removed extraneous whitespace from line ends...)
 #
 # 0.5.15
 # 	- fixed unbind error when aliasing a previously un-aliased window

--- a/scripts/chanact.pl
+++ b/scripts/chanact.pl
@@ -440,19 +440,16 @@ sub cmd_window_unalias {
 	my $win = Irssi::active_win();
 	my $name = Irssi::active_win()->{name};
 
-	# chanact'ified windows have a name like this: X:servertag/name
+	# chanact'ified windows have a name like this: X:servertag/name. if we
+	# can't find anything like this we return and do not unbind nor renumber
+	# anything
 	my ($key, $tag) = split(/:/, $name);
-	($tag, $name) = split('/', $tag);
+	return unless $tag;
 
-	# remove alias only of we have a single character keybinding, if we
-	# haven't the name was not set by chanact, so we won't blindly unset
-	# stuff
-	if (length($key) == 1) {
-		$server->command("/bind -delete meta-$key");
-	} else {
-		Irssi::print("chanact: could not determine keybinding. ".
-			"Won't unbind anything");
-	}
+	($tag, $name) = split('/', $tag);
+	return unless (length($key) == 1);
+
+	$server->command("/bind -delete meta-$key");
 
 	# set the windowname back to it's old one. We don't bother checking
 	# for a vaild name here, as we want to remove the current one and if
@@ -578,6 +575,8 @@ Irssi::signal_add('nick mode changed', 'chanactHasChanged');
 # 	- now with 'use warnings'
 # 	- fix cmd_window_unalias call from cmd_window_alias
 # 	- fix Use of uninitialized value $name in hash element warnings
+# 	- return from cmd_window_unalias if the window has no valid
+# 	  chanact'ified name
 #
 # 0.5.14
 # 	- fix itemless window handling, thx Bazerka

--- a/scripts/chanact.pl
+++ b/scripts/chanact.pl
@@ -9,8 +9,8 @@ use vars qw($VERSION %IRSSI);
 
 $VERSION = "master";
 %IRSSI = (
-    authors     => 'BC-bd, Veli',
-    contact     => 'bd@bc-bd.org, veli@piipiip.net',
+    authors     => 'BC-bd',
+    contact     => 'bd@bc-bd.org',
     name        => 'chanact',
     description => 'Adds new powerful and customizable [Act: ...] item (chanelnames,modes,alias). Lets you give alias characters to windows so that you can select those with meta-<char>',
     license     => 'GNU GPLv2 or later',
@@ -29,13 +29,15 @@ $VERSION = "master";
 # Contributors
 #########
 #
-# veli@piipiip.net   /window_alias code
-# qrczak@knm.org.pl  chanact_abbreviate_names
-# qerub@home.se      Extra chanact_show_mode and chanact_chop_status
+# veli@piipiip.net    original /window_alias code
+# qrczak@knm.org.pl   chanact_abbreviate_names
+# qerub@home.se       Extra chanact_show_mode and chanact_chop_status
 # madduck@madduck.net Better channel aliasing (case-sensitive, cross-network)
 #                     chanact_filter_windowlist basis
-# Jan 'jast' Krueger <jast@heapsort.de>, 2004-06-22
-# Ivo Timmermans <ivo@o2w.nl>	win->{hilight} patch
+# jast@heapsort.de    Updated documentation
+# ivo@o2w.nl          win->{hilight} patch
+# Bazerka             base patch for sorting by level change
+#                     updated documentation
 # 
 #########
 # USAGE
@@ -467,7 +469,6 @@ sub cmd_window_unalias {
 	Irssi::print("chanact: moved wintow to refnum $refnum");
 }
 
-# function by veli@piipiip.net
 # Make an alias
 sub cmd_window_alias {
 	my ($data, $server, $witem) = @_;

--- a/scripts/chanact.pl
+++ b/scripts/chanact.pl
@@ -1,6 +1,8 @@
 use Irssi 20020101.0001 ();
+
 use strict;
-# FIXME use warning;
+use warnings;
+
 use Irssi::TextUI;
 
 use vars qw($VERSION %IRSSI);
@@ -232,8 +234,8 @@ sub chanact {
 	if ($needRemake) {
 		remake();
 	}
-	
-	$item->default_handler($get_size_only, $actString, undef, 1);
+
+	$item->default_handler($get_size_only, $actString, "", 1);
 }
 
 # build a hash to easily access special levels based on
@@ -460,7 +462,7 @@ sub cmd_window_unalias {
 	# we are renumbering, so move the window to the lowest available
 	# refnum.
 	my $refnum = 1;
-	while (Irssi::window_find_refnum($refnum) ne "") {
+	while (Irssi::window_find_refnum($refnum)) {
 		$refnum++;
 	}
 
@@ -505,9 +507,9 @@ sub cmd_window_alias {
 		my $old_refnum = $window->{refnum};
 
 		$winnum = $rn_start;
- 
+
 		# Find the first available slot and move the window
-		while (Irssi::window_find_refnum($winnum) ne "") { $winnum++; }
+		while (Irssi::window_find_refnum($winnum)) { $winnum++; }
 		$window->set_refnum($winnum);
 		
 		Irssi::print("Moved the window from $old_refnum to $winnum");
@@ -571,6 +573,7 @@ Irssi::signal_add('nick mode changed', 'chanactHasChanged');
 #
 # master
 # 	- fixed URL
+# 	- now with 'use warnings'
 #
 # 0.5.14
 # 	- fix itemless window handling, thx Bazerka

--- a/scripts/chanact.pl
+++ b/scripts/chanact.pl
@@ -5,14 +5,14 @@ use Irssi::TextUI;
 
 use vars qw($VERSION %IRSSI);
 
-$VERSION = "0.5.14";
+$VERSION = "master";
 %IRSSI = (
     authors     => 'BC-bd, Veli',
     contact     => 'bd@bc-bd.org, veli@piipiip.net',
     name        => 'chanact',
     description => 'Adds new powerful and customizable [Act: ...] item (chanelnames,modes,alias). Lets you give alias characters to windows so that you can select those with meta-<char>',
     license     => 'GNU GPLv2 or later',
-    url         => 'https://bc-bd.org/svn/repos/irssi/chanact'
+    url         => 'http://bc-bd.org/blog/irssi/'
 );
 
 # Adds new powerful and customizable [Act: ...] item (chanelnames,modes,alias).
@@ -568,6 +568,9 @@ Irssi::signal_add('nick mode changed', 'chanactHasChanged');
 ###
 #
 # Changelog
+#
+# master
+# 	- fixed URL
 #
 # 0.5.14
 # 	- fix itemless window handling, thx Bazerka

--- a/scripts/chanact.pl
+++ b/scripts/chanact.pl
@@ -495,7 +495,7 @@ sub cmd_window_alias {
 		$winname = $window->{name};
 	}
 
-	cmd_window_unalias($data, $server, $witem);
+	cmd_window_unalias("", $server, $witem);
 
 	my $winnum = $window->{refnum};
 	
@@ -571,6 +571,7 @@ Irssi::signal_add('nick mode changed', 'chanactHasChanged');
 # master
 # 	- fixed URL
 # 	- now with 'use warnings'
+# 	- fix cmd_window_unalias call from cmd_window_alias
 #
 # 0.5.14
 # 	- fix itemless window handling, thx Bazerka

--- a/scripts/chanact.pl
+++ b/scripts/chanact.pl
@@ -227,7 +227,6 @@ sub expand {
 # but we dont need to recreate the item every time so we first
 # check if something has changed and only then we recreate the string
 # this might just save some cycles
-# FIXME implement $get_size_only check, and user $item->{min|max-size}
 sub chanact {
 	my ($item, $get_size_only) = @_;
 
@@ -263,8 +262,6 @@ sub calculate_levels(@) {
 	my %levels;
 
 	foreach my $win (@windows) {
-		# FIXME we could use the next statements to weed out entries in
-		# @windows that we will not need later on
 		!ref($win) && next;
 
 		my $name = $win->get_active_name;

--- a/scripts/chanact.pl
+++ b/scripts/chanact.pl
@@ -267,8 +267,10 @@ sub calculate_levels(@) {
 		!ref($win) && next;
 
 		my $name = $win->get_active_name;
+		# skip nameless windows
+		next unless $name;
 
-		if (exists($matches{$name})) {
+		if ($name && exists($matches{$name})) {
 			$levels{$name} = $matches{$name};
 		} else {
 			$levels{$name} = $default;
@@ -311,6 +313,8 @@ sub remake() {
 		$type = $active->{type} if $active;
 
 		my $name = $win->get_active_name;
+		# skip windows without a name
+		next unless $name;
 
 		my $filter_level =
 			$type eq 'QUERY' ? $levels{'@QUERIES'} : $levels{$name};
@@ -573,6 +577,7 @@ Irssi::signal_add('nick mode changed', 'chanactHasChanged');
 # 	- fixed URL
 # 	- now with 'use warnings'
 # 	- fix cmd_window_unalias call from cmd_window_alias
+# 	- fix Use of uninitialized value $name in hash element warnings
 #
 # 0.5.14
 # 	- fix itemless window handling, thx Bazerka

--- a/scripts/chanact.pl
+++ b/scripts/chanact.pl
@@ -467,7 +467,7 @@ sub cmd_window_unalias {
 	}
 
 	$win->set_refnum($refnum);
-	Irssi::print("chanact: moved wintow to refnum $refnum");
+	Irssi::print("chanact: moved window to refnum $refnum");
 }
 
 # Make an alias


### PR DESCRIPTION
The version of `chanact.pl` in this repository had diverged from upstream (#338). I've now cherry-picked upstreams commits and merged them with the local changes. It remains to be seen if upstream will now adopt these changes, or simply refer people to this repository as canonical source of `chanact.pl`. His Git repository is currently, unfortunately, unavailable.

Closes: #338