### PR TITLE
[trigger.pl] Save triggers idempotently

### DIFF
--- a/scripts/trigger.pl
+++ b/scripts/trigger.pl
@@ -982,14 +982,14 @@ sub to_string {
 	my ($trigger, $compat) = @_;
 	my $string;
 
-	foreach my $switch (@trigger_switches) {
+	foreach my $switch (sort @trigger_switches) {
 		if ($trigger->{$switch}) {
 			$string .= '-'.$switch.' ';
 		}
 	}
 
 	if ($compat) {
-		foreach my $filter (keys(%filters)) {
+		foreach my $filter (sort keys(%filters)) {
 			if ($trigger->{$filter}) {
 				$string .= '-' . $filter . param_to_string($trigger->{$filter});
 			}
@@ -1000,7 +1000,7 @@ sub to_string {
 		}
 	}
 
-	foreach my $param (@trigger_params) {
+	foreach my $param (sort @trigger_params) {
 		if ($trigger->{$param} || ($param eq 'replace' && defined($trigger->{'replace'}))) {
 			$string .= '-' . $param . param_to_string($trigger->{$param});
 		}

--- a/scripts/trigger.pl
+++ b/scripts/trigger.pl
@@ -981,13 +981,13 @@ sub param_to_string {
 sub to_string {
 	my ($trigger, $compat) = @_;
 	my $string;
-	
+
 	foreach my $switch (@trigger_switches) {
 		if ($trigger->{$switch}) {
 			$string .= '-'.$switch.' ';
 		}
 	}
-	
+
 	if ($compat) {
 		foreach my $filter (keys(%filters)) {
 			if ($trigger->{$filter}) {
@@ -1005,6 +1005,7 @@ sub to_string {
 			$string .= '-' . $param . param_to_string($trigger->{$param});
 		}
 	}
+	$string =~ s/\s+$//;
 	return $string;
 }
 


### PR DESCRIPTION
`/trigger save` writes out switches and parameters in the (random) order as return by iterating a Perl hash. In addition, there's a trailing new line on each saved trigger. Both of these make it slightly harder to track the Irssi configuration in a VCS such as Git.

This PR thus makes two changes that shouldn't have any effect on functionality:

1. Remove the trailing newline
1. Sort the switches and parameters before writing them to a file so that their order becomes well-defined.

I also accidentally removed trailing whitespace in the code (2 occurrences), but I think this is okay to be included and thus I didn't go through the hassle to get that part of the commit removed.

Signed-off-by: martin f. krafft <madduck@madduck.net>