### PR TITLE
[adv_windowlist] Extend shortcut search with window name match

### DIFF
--- a/scripts/adv_windowlist.pl
+++ b/scripts/adv_windowlist.pl
@@ -474,7 +474,7 @@ sub get_keymap {
 		if (/^change_window (\d+)/i) {
 		    $nummap{$1} = $map;
 		}
-		elsif (/^command window goto (\S+)/i) {
+		elsif (/^(?:command window goto|change_window) (\S+)/i) {
 		    my $window = $1;
 		    if ($window !~ /\D/) {
 			$nummap{$window} = $map;


### PR DESCRIPTION
This is a simple patch suggested by Nei to enable AWL to discern the
shortcut for a window also if the keybinding selects the window by name,
not its number.

Signed-off-by: martin f. krafft <madduck@madduck.net>