### PR TITLE
[ctrlact] Show the window refnum in debug output if there's not window name

### DIFF
--- a/scripts/ctrlact.pl
+++ b/scripts/ctrlact.pl
@@ -342,7 +342,7 @@ sub maybe_inhibit_win_hilight {
 		my ($th, $tth, $match) = get_win_threshold($wname, $wtag);
 		my $inhibit = $newlevel > 0 && $newlevel < $th;
 		debugprint(sprintf(DEBUGEVENTFORMAT, 'window', $wtag,
-				$wname?$wname:'(unnamed)', $newlevel,
+				$wname?$wname:"$win->{'refnum'}(unnamed)", $newlevel,
 				$inhibit ? ('<',$th,'inhibit'):('≥',$th,'pass'),
 				$tth, $match));
 		inhibit_win_hilight($win) if $inhibit;


### PR DESCRIPTION
Signed-off-by: martin f. krafft <madduck@madduck.net>