### PR TITLE
trigger.pl: default address to empty in mask match

### DIFF
--- a/scripts/trigger.pl
+++ b/scripts/trigger.pl
@@ -456,7 +456,8 @@ my %filters = (
 	'types' => \@all_types,
 	'sub' => sub {
 		my ($param, $signal,$parammessage,$server,$channelname,$nickname,$address,$condition,$extra) = @_;
-		return  (defined($nickname) && defined($address) && defined($server) && $server->masks_match($param, $nickname, $address));
+		$address //= '';
+		return  (defined($nickname) && defined($server) && $server->masks_match($param, $nickname, $address));
 	}
 },
 'other_masks' => {

--- a/scripts/trigger.pl
+++ b/scripts/trigger.pl
@@ -23,7 +23,7 @@ use Text::ParseWords;
 use IO::File;
 use vars qw($VERSION %IRSSI);
 
-$VERSION = '1.0+';
+$VERSION = '1.1';
 %IRSSI = (
 	authors     => 'Wouter Coekaerts',
 	contact     => 'wouter@coekaerts.be',


### PR DESCRIPTION
Server notices are included in the privnotices type, but their address parameter is undefined, because the prefix of the message is just the server name.  By defaulting address to an empty string in the masks match, we can match server notices easily with `-privnotices -masks '<servername>!'` instead of a really messy rawin + regexp.  (Irssi merges the nick and address passed into masks_match with a `%s!%s` format string, so there'll be a trailing "!" when address is an empty string.)