### PR TITLE
autorejoin: Add settings, general cleanup

### DIFF
--- a/scripts/autorejoin.pl
+++ b/scripts/autorejoin.pl
@@ -1,5 +1,8 @@
-# automatically rejoin to channel after kick
+# automatically rejoin to channel after kicked
 # delayed rejoin: Lam 28.10.2001 (lam@lac.pl)
+
+# /SET autorejoin_channels #channel1 #channel2 ...
+# /SET autorejoin_delay 5
 
 # NOTE: I personally don't like this feature, in most channels I'm in it
 # will just result as ban. You've probably misunderstood the idea of /KICK
@@ -9,31 +12,22 @@ use Irssi;
 use Irssi::Irc;
 use strict;
 use vars qw($VERSION %IRSSI);
-$VERSION = "1.0.0";
+$VERSION = "1.1.0";
 %IRSSI = (
 	authors => "Timo 'cras' Sirainen, Leszek Matok",
 	contact => "lam\@lac.pl",
 	name => "autorejoin",
-	description => "Automatically rejoin to channel after being kick, after a (short) user-defined delay",
+	description => "Automatically rejoin to channel after being kicked, after a (short) user-defined delay",
 	license => "GPLv2",
 	changed => "10.3.2002 14:00"
 );
 
-
-# How many seconds to wait before the rejoin?
-# TODO: make this a /setting
-my $delay = 5;
-
-my @tags;
-my $acttag = 0;
-
 sub rejoin {
 	my ( $data ) = @_;
-	my ( $tag, $servtag, $channel, $pass ) = split( / +/, $data );
+	my ( $servtag, $channel, $pass ) = @{$data};
 
 	my $server = Irssi::server_find_tag( $servtag );
 	$server->send_raw( "JOIN $channel $pass" ) if ( $server );
-	Irssi::timeout_remove( $tags[$tag] );
 }
 
 sub event_rejoin_kick {
@@ -48,10 +42,31 @@ sub event_rejoin_kick {
 	my $rejoinchan = $chanrec->{ name } if ( $chanrec );
 	my $servtag = $server->{ tag };
 
-	Irssi::print "Rejoining $rejoinchan in $delay seconds.";
-	$tags[$acttag] = Irssi::timeout_add( $delay * 1000, "rejoin", "$acttag $servtag $rejoinchan $password" );
-	$acttag++;
-	$acttag = 0 if ( $acttag > 60 );
+	# check if we want to autorejoin this channel
+	my $chans = Irssi::settings_get_str( 'autorejoin_channels' );
+
+	if ( $chans ) {
+		my $found = 0;
+		foreach my $chan ( split( /[ ,]/, $chans ) ) {
+			if ( lc( $chan ) eq lc( $channel ) ) {
+				$found = 1;
+				last;
+			}
+		}
+		return unless $found;
+	}
+
+	my @args = ($servtag, $rejoinchan, $password);
+	my $delay = Irssi::settings_get_int( "autorejoin_delay" );
+
+	if ($delay) {
+		Irssi::print "Rejoining $rejoinchan in $delay seconds.";
+		Irssi::timeout_add_once( $delay * 1000, "rejoin", \@args );
+	} else {
+		rejoin( \@args );
+	}
 }
 
+Irssi::settings_add_int('misc', 'autorejoin_delay', 5);
+Irssi::settings_add_str('misc', 'autorejoin_channels', '');
 Irssi::signal_add( 'event kick', 'event_rejoin_kick' );


### PR DESCRIPTION
This merges the idea of `autorejoin_channels` from the version of the script at http://wouter.coekaerts.be/irssi/scripts/autorejoin.pl

The version in this repository had different indentation and the timeout delay stuff, so the end result is nothing like that one. Also that one says Public Domain. Whatever.

This adds two settings:

- `autorejoin_delay`: time in seconds, defaults to 5, as the old code. Can be set to 0 to autorejoin instantly (like the other script)
- `autorejoin_channels`: channels whitelisted for autorejoin, applies to all channels if empty.

Not a fan of having this enabled for all channels, but it's the most backwards-compatible behavior with the version of the script that was in this repo. The other version defaulted to nothing.

This also changes the `timeout_add` into `timeout_add_once` and cleans up parameter passing and acttag handling.

Also a couple of s/kick/kicked/ from the other script