### PR TITLE
fix bug with empty filelist and add code for missing modver handling

### DIFF
--- a/_testing/travis/autoinstall-perl-prereqs.zsh
+++ b/_testing/travis/autoinstall-perl-prereqs.zsh
@@ -5,7 +5,12 @@ mkdir -p auto
 . ./_testing/_get_files_arr.zsh
 
 echo -n ... >&2
-scan-perl-prereqs $filelist > auto/cpanfile
+if [[ ${#filelist} -eq 0 ]] {
+    touch auto/cpanfile
+} \
+else {
+    scan-perl-prereqs $filelist > auto/cpanfile
+}
 
 typeset -A broken_mods
 broken_mods=($(perl -MYAML::Tiny=LoadFile -e'print "$_ 1 " for @{LoadFile(+shift)->{cpan}{broken_modules}}' _testing/config.yml))
@@ -17,6 +22,7 @@ sed -i \
     -e '/^Irssi~/d' \
     -e '/^Irssi::/d' \
     $sed_del_broken \
+    -e 's/~/"'","'"/g' \
     -e 's,^,'"'"',g' \
     -e 's,$,'"'"',g' \
     -e 's,^,requires ,g' \


### PR DESCRIPTION
- empty filelist can happen on module removal (see #448 )
- triggered the default behaviour of the module scanner, which will then scan more files than it should
- uncovered missing version handling (`~` syntax)