### PR TITLE
[mpd.pl] unescaped left brace in regex becomes an error in perl5 v26

### DIFF
--- a/scripts/mpd.pl
+++ b/scripts/mpd.pl
@@ -96,7 +96,7 @@ sub np {
             $ans = <$socket>;
         }
 
-        if ($ans =~ /^ACK \[...\] {.*?} (.*)$/){
+        if ($ans =~ /^ACK \[...\] \{.*?\} (.*)$/){
             my_status_print('Auth Error: '.$1, $witem);
             close $socket;
             return;
@@ -120,7 +120,7 @@ sub np {
     print $socket "status\n";
     while (not $ans =~ /^(OK$|ACK)/) {
         $ans = <$socket>;
-        if ($ans =~ /^ACK \[...\] {.*?} (.*)$/){
+        if ($ans =~ /^ACK \[...\] \{.*?\} (.*)$/){
             my_status_print($1, $witem);
             close $socket;
             return;


### PR DESCRIPTION
I just escaped the braces in the regex statements as it becomes an error that lets the script crash in the current version of perl