### PR TITLE
[oops] Also call /names on ll

### DIFF
--- a/scripts/oops.pl
+++ b/scripts/oops.pl
@@ -2,32 +2,32 @@ use strict;
 use vars qw($VERSION %IRSSI);
 
 use Irssi;
-$VERSION = '20071209';
+$VERSION = '20180707';
 %IRSSI = (
     authors     => '',
     contact     => '',
     name        => 'oops',
     description =>
-'turns \'ll\' and \'ls\' in the beginning of a sent line into the names or whois commands',
+    'turns \'ll\' and \'ls\' in the beginning of a sent line into the names or whois commands',
     license => 'Public Domain',
-);
+    );
 
 sub send_text {
-    my $pattern = qr/(^ll |^ll$|^ls |^ls$)/;
+    my $pattern = qr/(^(ll|ls)\s*$)/;
 
     #"send text", char *line, SERVER_REC, WI_ITEM_REC
     my ( $data, $server, $witem ) = @_;
-    if ( $witem
-        && ( $witem->{type} eq "CHANNEL" )
-        && ( $data =~ $pattern ) )
-    {
-        $witem->command("names $witem->{name}");
-        Irssi::signal_stop();
-    }
-    if ( $witem && ( $witem->{type} eq "QUERY" ) && ( $data =~ $pattern ) )
-    {
-        $witem->command("whois $witem->{name}");
-        Irssi::signal_stop();
+    if($data =~ $pattern) {
+        if($witem->{type} eq "CHANNEL")
+        {
+            $witem->command("names $witem->{name}");
+            Irssi::signal_stop();
+        }
+        elsif($witem->{type} eq "QUERY")
+        {
+            $witem->command("whois $witem->{name}");
+            Irssi::signal_stop();
+        }
     }
 }
 

--- a/scripts/oops.pl
+++ b/scripts/oops.pl
@@ -8,22 +8,23 @@ $VERSION = '20071209';
     contact     => '',
     name        => 'oops',
     description =>
-'turns \'ls\' in the beginning of a sent line into the names or whois commands',
+'turns \'ll\' and \'ls\' in the beginning of a sent line into the names or whois commands',
     license => 'Public Domain',
 );
 
 sub send_text {
+    my $pattern = qr/(^ll |^ll$|^ls |^ls$)/;
 
     #"send text", char *line, SERVER_REC, WI_ITEM_REC
     my ( $data, $server, $witem ) = @_;
     if ( $witem
         && ( $witem->{type} eq "CHANNEL" )
-        && ( $data =~ /(^ls |^ls$)/ ) )
+        && ( $data =~ $pattern ) )
     {
         $witem->command("names $witem->{name}");
         Irssi::signal_stop();
     }
-    if ( $witem && ( $witem->{type} eq "QUERY" ) && ( $data =~ /(^ls |^ls$)/ ) )
+    if ( $witem && ( $witem->{type} eq "QUERY" ) && ( $data =~ $pattern ) )
     {
         $witem->command("whois $witem->{name}");
         Irssi::signal_stop();


### PR DESCRIPTION
ll is aliased to `ls -l` on a lot of distributions by default and has made its
way into (at least my) muscle memory right next to regular ls.