### PR TITLE
[nicklist] Improve terminal compatiblity of screen mode

### DIFF
--- a/scripts/nicklist.pl
+++ b/scripts/nicklist.pl
@@ -22,7 +22,7 @@ use strict;
 use IO::Handle; # for (auto)flush
 use Fcntl; # for sysopen
 use vars qw($VERSION %IRSSI);
-$VERSION = '0.4.11';
+$VERSION = '0.4.12';
 %IRSSI = (
 	authors     => 'Wouter Coekaerts',
 	contact     => 'coekie@irssi.org',
@@ -30,7 +30,7 @@ $VERSION = '0.4.11';
 	description => 'draws a nicklist to another terminal, or at the right of your irssi in the same terminal',
 	license     => 'GPLv2',
 	url         => 'http://wouter.coekaerts.be/irssi',
-	changed     => '2018-06-02'
+	changed     => '2018-10-02'
 );
 
 sub cmd_help {
@@ -287,13 +287,13 @@ sub sig_terminal_resized {
 
 sub nicklist_write_start {
 	if ($mode == $SCREEN) {
-		print STDERR "\033P\033[s\033\\"; # save cursor
+		print STDERR "\033P\0337\033\\"; # save cursor
 	}
 }
 
 sub nicklist_write_end {
 	if ($mode == $SCREEN) {
-		print STDERR "\033P\033[u\033\\"; # restore cursor
+		print STDERR "\033P\0338\033\\"; # restore cursor
 	}
 }
 


### PR DESCRIPTION
In screen mode, nicklist.pl uses the obscure escape sequences CSI s and
CSI u to save and restore the cursor position; on top of that, it uses
ESC P to bypass screen's interpretation of these escape sequences, passing
them directly to the underlying terminal.

While I did not investigate whether this makes sense at all - bypassing
screen's position tracking seems dangerous at best - this fix improves
terminal compatiblity by replacing CSI s and CSI u with the more common
ESC 7 and ESC 8 sequences [1].

The issue surfaced then vte3 replaced their parser, removing support for
CSI s and CSI u [2]. While support has been restored in the latest master
[3], using the more compatible escape sequences in nicklist.pl generally
seems like a good idea.

[1] https://gitlab.gnome.org/GNOME/vte/issues/48
[2] https://gitlab.gnome.org/GNOME/vte/issues/55
[3] https://gitlab.gnome.org/GNOME/vte/commit/f86cae603b23d34e36ab95fde6612bfc4d5eeca8