### PR TITLE
go.pl: fix short circuiting during channel search

### DIFF
--- a/scripts/go.pl
+++ b/scripts/go.pl
@@ -29,7 +29,7 @@ use Irssi::Irc;
 #     completion. The leading '#' of channel names is optional either way.
 #
 
-$VERSION = '1.1';
+$VERSION = '1.1.1';
 
 %IRSSI = (
     authors     => 'nohar',
@@ -37,7 +37,7 @@ $VERSION = '1.1';
     name        => 'go to window',
     description => 'Implements /go command that activates a window given a name/partial name. It features a nice completion.',
     license     => 'GPLv2 or later',
-    changed     => '2017-02-02'
+    changed     => '2019-02-25'
 );
 
 sub _make_regexp {
@@ -81,12 +81,18 @@ sub cmd_go
 		Irssi::settings_get_bool('go_match_case_sensitive'),
 		Irssi::settings_get_bool('go_match_anchored'));
 
+	my @matches = [];
 	foreach my $w (Irssi::windows) {
 		my $name = $w->get_active_name();
-		if ($name =~ $re) {
+		if ($name =~ /$re$/) {
 			$w->set_active();
 			return;
+		} elsif ($name =~ /$re/) {
+			push(@matches, $w);
 		}
+	}
+	if (@matches) {
+		$matches[0]->set_active()
 	}
 }
 
@@ -103,3 +109,5 @@ Irssi::settings_add_bool('go', 'go_complete_anchored', 0);
 #   - made case-sensitivity of match configurable
 #   - made anchoring of search strings configurable
 #
+# 2019-02-025  1.1.1  dylan lloyd <dylan@disinclined.org>
+#   - fixed short-circuiting during channel search

--- a/scripts/go.pl
+++ b/scripts/go.pl
@@ -110,4 +110,4 @@ Irssi::settings_add_bool('go', 'go_complete_anchored', 0);
 #   - made anchoring of search strings configurable
 #
 # 2019-02-025  1.1.1  dylan lloyd <dylan@disinclined.org>
-#   - fixed short-circuiting during channel search
+#   - prefer exact channel matches

--- a/scripts/go.pl
+++ b/scripts/go.pl
@@ -84,7 +84,7 @@ sub cmd_go
 	my @matches;
 	foreach my $w (Irssi::windows) {
 		my $name = $w->get_active_name();
-		if ($name =~ /$re$/) {
+		if (fc $name eq fc $chan) {
 			$w->set_active();
 			return;
 		} elsif ($name =~ /$re/) {

--- a/scripts/go.pl
+++ b/scripts/go.pl
@@ -76,15 +76,17 @@ sub cmd_go
 {
 	my($chan,$server,$witem) = @_;
 
+	my $case_sensitive = Irssi::settings_get_bool('go_match_case_sensitive');
+	my $match_anchored = Irssi::settings_get_bool('go_match_anchored');
+
 	$chan =~ s/ *//g;
-	my $re = _make_regexp($chan,
-		Irssi::settings_get_bool('go_match_case_sensitive'),
-		Irssi::settings_get_bool('go_match_anchored'));
+	my $re = _make_regexp($chan, $case_sensitive, $match_anchored);
 
 	my @matches;
 	foreach my $w (Irssi::windows) {
 		my $name = $w->get_active_name();
-		if (CORE::fc $name eq CORE::fc $chan) {
+		if (($case_sensitive && $name eq $chan) ||
+			(!$case_sensitive && CORE::fc $name eq CORE::fc $chan)) {
 			$w->set_active();
 			return;
 		} elsif ($name =~ /$re/) {

--- a/scripts/go.pl
+++ b/scripts/go.pl
@@ -84,7 +84,7 @@ sub cmd_go
 	my @matches;
 	foreach my $w (Irssi::windows) {
 		my $name = $w->get_active_name();
-		if (fc $name eq fc $chan) {
+		if (CORE::fc $name eq CORE::fc $chan) {
 			$w->set_active();
 			return;
 		} elsif ($name =~ /$re/) {

--- a/scripts/go.pl
+++ b/scripts/go.pl
@@ -81,7 +81,7 @@ sub cmd_go
 		Irssi::settings_get_bool('go_match_case_sensitive'),
 		Irssi::settings_get_bool('go_match_anchored'));
 
-	my @matches = [];
+	my @matches;
 	foreach my $w (Irssi::windows) {
 		my $name = $w->get_active_name();
 		if ($name =~ /$re$/) {
@@ -92,7 +92,7 @@ sub cmd_go
 		}
 	}
 	if (@matches) {
-		$matches[0]->set_active()
+		$matches[0]->set_active();
 	}
 }
 


### PR DESCRIPTION
example: currently `/go #vim` when `#vim` and `#vim-ale` are both open will incorrectly go to `#vim-ale` depending on the order of your windows. this fixes that.