### PR TITLE
Fix quoting of version requirements in autoinstall-perl-prereqs

### DIFF
--- a/_testing/autoinstall-perl-prereqs.zsh
+++ b/_testing/autoinstall-perl-prereqs.zsh
@@ -28,7 +28,7 @@ sed -i \
     -e '/^Irssi~/d' \
     -e '/^Irssi::/d' \
     $sed_del_broken \
-    -e 's/~/"'","'"/g' \
+    -e 's/~/'"','"'/g' \
     -e 's,^,'"'"',g' \
     -e 's,$,'"'"',g' \
     -e 's,^,requires ,g' \


### PR DESCRIPTION
uncovered by #624 