### PR TITLE
[fnotify] Add own messages to fnotify writes

### DIFF
--- a/scripts/fnotify.pl
+++ b/scripts/fnotify.pl
@@ -7,7 +7,7 @@ $VERSION = '0.0.7';
 %IRSSI = (
 	name => 'fnotify',
 	authors => 'Tyler Abair, Thorsten Leemhuis, James Shubin' .
-               ', Serge van Ginderachter',
+               ', Serge van Ginderachter, Michael Davies',
 	contact => 'fedora@leemhuis.info, serge@vanginderachter.be',
 	description => 'Write notifications to a file in a consistent format.',
 	license => 'GNU General Public License',
@@ -22,6 +22,7 @@ $VERSION = '0.0.7';
 # irssi> /load perl
 # irssi> /script load fnotify
 # irssi> /set fnotify_ignore_hilight 0 # ignore hilights of priority 0
+# irssi> /set fnotify_showself on      # turn on own notifications
 #
 
 #
@@ -63,9 +64,13 @@ my %config;
 Irssi::settings_add_int('fnotify', 'fnotify_ignore_hilight' => -1);
 $config{'ignore_hilight'} = Irssi::settings_get_int('fnotify_ignore_hilight');
 
+Irssi::settings_add_str('fnotify', 'fnotify_showself' => "off");
+$config{'showself'} = Irssi::settings_get_str('fnotify_showself');
+
 Irssi::signal_add(
     'setup changed' => sub {
         $config{'ignore_hilight'} = Irssi::settings_get_int('fnotify_ignore_hilight');
+        $config{'showself'} = Irssi::settings_get_str('fnotify_showself');
     }
 );
 
@@ -97,12 +102,16 @@ sub hilight {
 #
 sub own_public {
 	my ($dest, $msg, $target) = @_;
-	filewrite($dest->{'nick'} . ' ' .$msg );
+	if (lc($config{'showself'}) eq 'on') {
+		filewrite($dest->{'nick'} . ' ' .$msg );
+	}
 }
 
 sub own_private {
 	my ($dest, $msg, $target, $orig_target) = @_;
-	filewrite($dest->{'nick'} . ' ' .$msg );
+	if (lc($config{'showself'}) eq 'on') {
+		filewrite($dest->{'nick'} . ' ' .$msg );
+	}
 }
 
 #

--- a/scripts/fnotify.pl
+++ b/scripts/fnotify.pl
@@ -3,7 +3,7 @@ use warnings;
 use vars qw($VERSION %IRSSI);
 use Irssi;
 
-$VERSION = '0.0.6';
+$VERSION = '0.0.7';
 %IRSSI = (
 	name => 'fnotify',
 	authors => 'Tyler Abair, Thorsten Leemhuis, James Shubin' .
@@ -26,6 +26,10 @@ $VERSION = '0.0.6';
 
 #
 #	AUTHORS
+#
+# Add self to notification file
+# version 0.0.7
+# Michael Davies <michael@the-davies.net>
 #
 # Ignore hilighted messages with priority = fnotify_ignore_hilight
 # version: 0.0.6
@@ -89,6 +93,19 @@ sub hilight {
 }
 
 #
+#	catch own messages
+#
+sub own_public {
+	my ($dest, $msg, $target) = @_;
+	filewrite($dest->{'nick'} . ' ' .$msg );
+}
+
+sub own_private {
+	my ($dest, $msg, $target, $orig_target) = @_;
+	filewrite($dest->{'nick'} . ' ' .$msg );
+}
+
+#
 #	write to file
 #
 sub filewrite {
@@ -109,4 +126,6 @@ sub filewrite {
 #
 Irssi::signal_add_last("message private", "priv_msg");
 Irssi::signal_add_last("print text", "hilight");
+Irssi::signal_add_last("message own_public", "own_public");
+Irssi::signal_add_last("message own_private", "own_private");
 

--- a/scripts/fnotify.pl
+++ b/scripts/fnotify.pl
@@ -22,7 +22,7 @@ $VERSION = '0.0.7';
 # irssi> /load perl
 # irssi> /script load fnotify
 # irssi> /set fnotify_ignore_hilight 0 # ignore hilights of priority 0
-# irssi> /set fnotify_showself on      # turn on own notifications
+# irssi> /set fnotify_own on           # turn on own notifications
 #
 
 #
@@ -64,13 +64,13 @@ my %config;
 Irssi::settings_add_int('fnotify', 'fnotify_ignore_hilight' => -1);
 $config{'ignore_hilight'} = Irssi::settings_get_int('fnotify_ignore_hilight');
 
-Irssi::settings_add_str('fnotify', 'fnotify_showself' => "off");
-$config{'showself'} = Irssi::settings_get_str('fnotify_showself');
+Irssi::settings_add_bool('fnotify', 'fnotify_own', 0);
+$config{'own'} = Irssi::settings_get_bool('fnotify_own');
 
 Irssi::signal_add(
     'setup changed' => sub {
         $config{'ignore_hilight'} = Irssi::settings_get_int('fnotify_ignore_hilight');
-        $config{'showself'} = Irssi::settings_get_str('fnotify_showself');
+        $config{'own'} = Irssi::settings_get_bool('fnotify_own');
     }
 );
 
@@ -102,14 +102,14 @@ sub hilight {
 #
 sub own_public {
 	my ($dest, $msg, $target) = @_;
-	if (lc($config{'showself'}) eq 'on') {
+	if ($config{'own'}) {
 		filewrite($dest->{'nick'} . ' ' .$msg );
 	}
 }
 
 sub own_private {
 	my ($dest, $msg, $target, $orig_target) = @_;
-	if (lc($config{'showself'}) eq 'on') {
+	if ($config{'own'}) {
 		filewrite($dest->{'nick'} . ' ' .$msg );
 	}
 }


### PR DESCRIPTION
fnotify allows you to do things like turn on blinkenlights when you are
hilighted in messages. Adding your own messages allows you to turn off
any local notifications once you respond.

Sample of how to do this is at
https://github.com/mrda/junkcode/blob/master/irssi-notify.sh