### PR TITLE
Update quitrand.pl

### DIFF
--- a/scripts/quitrand.pl
+++ b/scripts/quitrand.pl
@@ -20,21 +20,17 @@ my $quitfile = glob "~/.irssi/irssi.quit";
 sub cmd_quit {
 	my ($data, $server, $channel) = @_;
 	
-	open(f,"<",$quitfile);
-	my @contenido = <f>;
-	close(f);
+	open(my $fh,"<",$quitfile);
+	my @contenido = <$fh>;
+	close($fh);
 
-	my $numlines = 0;
-	
-	foreach my $nada (@contenido) {
-		$numlines++;
-	}
+	my $numlines = 0+@contenido;
 
 	my $line = int(rand($numlines))+1;
 
 	my $quitmsg = "[IRSSI] ".$contenido[$line];
 
-	chop($quitmsg);
+	chomp($quitmsg);
 
 	print($quitmsg);
 


### PR DESCRIPTION
Clean up the perl a little.  Remove an uneccesary loop, use a lexical file handle to avoid possible conflicts, and use chomp instead of chop.  chomp will only remove the newline rather than any last character in the line.  This fixes a potential bug for the last message in the file if the file doesn't end in a newline.