### PR TITLE
Detect irssi scripts as proper Perl

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.pl linguist-language=Perl


### PR DESCRIPTION
As it is right now, some scripts in this repo @ GitHub are detected as [Prolog](https://github.com/irssi/scripts.irssi.org/search?l=Prolog), not Perl, which screws up their syntax coloring in creative ways, e.g. [`scriptassist.pl`](https://github.com/irssi/scripts.irssi.org/blob/a6664390ca88cddc057606a7aabf6e077dd99207/scripts/scriptassist.pl), [`adv_windowlist.pl`](https://github.com/irssi/scripts.irssi.org/blob/e560b26dc8030de89dd72c4955e389da2241e706/scripts/adv_windowlist.pl), [`newsline.pl`](https://github.com/irssi/scripts.irssi.org/blob/a6664390ca88cddc057606a7aabf6e077dd99207/scripts/newsline.pl).

This PR aims to fix that by slamming a line in `.gitattributes` overriding this (I have no idea how does this work by default, and why only a subset of Perl scripts is affected).

(Note: this won't work immediately - linguist job has to visit this repo)