### PR TITLE
[trigger.pl] Sort trigger filters prior to save for idempotency

### DIFF
--- a/scripts/trigger.pl
+++ b/scripts/trigger.pl
@@ -675,7 +675,8 @@ TRIGGER:
 # return array of filters for the given trigger
 sub filters_for_trigger($) {
 	my ($trigger) = @_;
-	return values(%{$trigger->{'filters'}});
+	my $href = $trigger->{filters};
+	return @{$href}{ sort keys %$href };
 }
 
 # used in check_signal_message to expand $'s
@@ -1001,7 +1002,7 @@ sub to_string {
 	}
 	
 	if ($compat) {
-		foreach my $filter (keys(%filters)) {
+		foreach my $filter (sort keys(%filters)) {
 			if ($trigger->{$filter}) {
 				$string .= '-' . $filter . param_to_string($trigger->{$filter});
 			}

--- a/scripts/trigger.pl
+++ b/scripts/trigger.pl
@@ -23,7 +23,7 @@ use Text::ParseWords;
 use IO::File;
 use vars qw($VERSION %IRSSI);
 
-$VERSION = '1.2.4';
+$VERSION = '1.2.5';
 %IRSSI = (
 	authors     => 'Wouter Coekaerts',
 	contact     => 'wouter@coekaerts.be',
@@ -31,7 +31,7 @@ $VERSION = '1.2.4';
 	description => 'execute a command or replace text, triggered by an event in irssi',
 	license     => 'GPLv2 or later',
 	url         => 'http://wouter.coekaerts.be/irssi/',
-	changed     => '2020-03-10',
+	changed     => '2022-01-02',
 );
 
 sub cmd_help {


### PR DESCRIPTION
For those of us keeping config in Git, it's a bit annoying when trigger changes the order based on the time of day and moon phase (i.e. hash order is undefined) on each config save, so let's sort the lines to make it a bit more idempotent.

Signed-off-by: martin f. krafft <madduck@madduck.net>