### PR TITLE
Trim final space from saved trigger lines

### DIFF
--- a/scripts/trigger.pl
+++ b/scripts/trigger.pl
@@ -1017,6 +1017,7 @@ sub to_string {
 			$string .= '-' . $param . param_to_string($trigger->{$param});
 		}
 	}
+	$string =~ s/\s+$//;
 	return $string;
 }
 

--- a/scripts/trigger.pl
+++ b/scripts/trigger.pl
@@ -993,13 +993,13 @@ sub param_to_string {
 sub to_string {
 	my ($trigger, $compat) = @_;
 	my $string;
-	
+
 	foreach my $switch (@trigger_switches) {
 		if ($trigger->{$switch}) {
 			$string .= '-'.$switch.' ';
 		}
 	}
-	
+
 	if ($compat) {
 		foreach my $filter (keys(%filters)) {
 			if ($trigger->{$filter}) {


### PR DESCRIPTION
/trigger save would end lines with a trailing space, which makes Git
complain about it. There's no reason this space needs to exist, so let's
get rid of it.

Signed-off-by: martin f. krafft <madduck@madduck.net>