### PR TITLE
[adv_windowlist.pl] Enable matching the F-keys as window changing shortcuts

### DIFF
--- a/scripts/adv_windowlist.pl
+++ b/scripts/adv_windowlist.pl
@@ -503,15 +503,26 @@ sub _add_map {
 sub get_keymap {
     my ($textDest, undef, $cont_stripped) = @_;
     if ($textDest->{level} == 524288 and $textDest->{target} eq '' and !defined $textDest->{server}) {
-	my $one_meta_or_ctrl_key = qr/((?:meta-)*?)(?:(meta-|\^)(\S)|(\w+))/;
+	my $one_meta_or_ctrl_key = qr/((?:meta-)*?)(?:(?:(meta-|\^)(\S)|(meta-|\^)?(F\d+))|(\w+))/;
 	$cont_stripped = as_uni($cont_stripped);
 	if ($cont_stripped =~ m/((?:$one_meta_or_ctrl_key-)*$one_meta_or_ctrl_key)\s+(.*)$/) {
-	    my ($combo, $command) = ($1, $10);
+	    my ($combo, $command) = ($1, $14);
 	    my $map = '';
 	    while ($combo =~ s/(?:-|^)$one_meta_or_ctrl_key$//) {
-		my ($level, $ctl, $key, $nkey) = ($1, $2, $3, $4);
+		my ($level, $ctl, $key, $fctl, $fkey, $nkey) = ($1, $2, $3, $4, $5, $6);
+		if (!defined $fkey) {
+			$ctl = '' if !$ctl || $ctl ne '^';
+		}
+		else {
+			# meta-F12 -> "F12" by convention
+			if($fctl eq 'meta-') { $ctl = ''; }
+			# so pure F12 -> "`F12"
+			elsif (!$fctl || $fctl eq '') { $ctl = '`'; }
+			# ^F12 stays ^F12
+			else { $ctl = $fctl; }
+			$key = $fkey;
+		}
 		my $numlevel = ($level =~ y/-//);
-		$ctl = '' if !$ctl || $ctl ne '^';
 		$map = ('-' x ($numlevel%2)) . ('+' x ($numlevel/2)) .
 		    $ctl . (defined $key ? $key : "\01$nkey\01") . $map;
 	    }


### PR DESCRIPTION
This enhances the AWL keymap parser to also match the use of F-keys
(i.e. F1 through F12), which will have to be mapped from their escape
sequences first (e.g. /bind ^[[11~ key F1).

The convention is followed that "meta-F1" gets displayed as "F1", and
"^F1" is shown as "^F1". Since it also makes sense to use F-keys without
modifiers, the syntax "`F1" is used to identify a "pure" F-key.

Signed-off-by: martin f. krafft <madduck@madduck.net>