### PR TITLE
[adv_windowlist.pl] Match against /go argument when determining $Q

### DIFF
--- a/scripts/adv_windowlist.pl
+++ b/scripts/adv_windowlist.pl
@@ -520,7 +520,7 @@ sub get_keymap {
 		if (/^change_window (\d+)/i) {
 		    _add_map(\%nummap, $1, $map);
 		}
-		elsif (/^(?:command window goto|change_window) (\S+)/i) {
+		elsif (/^(?:command (?:window goto|go)|change_window) (\S+)/i) {
 		    my $window = $1;
 		    if ($window !~ /\D/) {
 			_add_map(\%nummap, $window, $map);


### PR DESCRIPTION
I've recently started using `go2.pl` (a drop-in replacement to `go.pl`),
which provides the handy `/go` command to switch windows. Consequently,
I can now do:

```
/bind meta-s-meta-i command go #irssi
```

to switch to the window containing the best match for item `#irssi`.

This patch teaches AWL to read the `/bind` output for such keybindings
as well, so that `$Q` works accordingly.

Signed-off-by: martin f. krafft <madduck@madduck.net>