### PR TITLE
Add yubikey.pl script

### DIFF
--- a/scripts/yubikey.pl
+++ b/scripts/yubikey.pl
@@ -1,0 +1,21 @@
+#!/usr/bin/env perl
+
+use strict;
+use vars qw($VERSION %IRSSI);
+use Irssi;
+
+$VERSION = "20151026";
+%IRSSI = (
+    authors     => "Philip Paeps",
+    contact     => "philip\@trouble.is",
+    name        => "yubikey",
+    description => "This script stops accidental YubiKey output on IRC",
+    license     => "BSD",
+    changed     => "$VERSION",
+);
+
+sub event_send_text {
+    my ($line, $server_rec, $wi_item_rec) = @_;
+    Irssi::signal_stop() if $line =~ /^cccccc/;
+}
+Irssi::signal_add_first('send text', \&event_send_text);


### PR DESCRIPTION
This script helps prevent accidentally sending YubiKey OTPs to IRC.

I wrote this many years ago.  Sharing it with the wider community after sharing it with another person whose cat likes to play with their YubiKey. :)