### PR TITLE
cron: Fix time drifting bug.

### DIFF
--- a/scripts/cron.pl
+++ b/scripts/cron.pl
@@ -75,7 +75,7 @@ use Irssi;
 use strict;
 use vars qw($VERSION %IRSSI);
 
-$VERSION = "0.12";
+$VERSION = "0.13";
 %IRSSI = (
     authors	=> 'Piotr Krukowiecki',
     contact	=> 'piotr \at/ krukowiecki /dot\ net',


### PR DESCRIPTION
Currently the code does this:
1. Get time
2. Start `sig_timeout` at next `hh:mm:00`
3. Re-run `sig_timeout` every 60 seconds. // This is the bug since it takes extra time (milliseconds) to run the command. That eventually adds up to seconds, then minutes...

My changes:

Re-run `sig_timeout` at every `hh:mm:00`