### PR TITLE
[autoop.pl] Chomp input line to strip trailing newline

### DIFF
--- a/scripts/autoop.pl
+++ b/scripts/autoop.pl
@@ -98,11 +98,11 @@ sub load_autoops {
     %opnicks = ();
     open(CONF, "<", "$file") or return;
     while (my $line = <CONF>) {
-		chomp($line);
-		if ($line !=~ /^\s*$/) {
-			cmd_autoop($line);
-			$count++;
-		}
+        chomp($line);
+        if ($line !~ /^\s*$/) {
+            cmd_autoop($line);
+            $count++;
+        }
     }
     close(CONF);
     


### PR DESCRIPTION
To ensure that the detected masks is matching against the configured masks, the input line need to be chomped to avoid including the `\n` in the matching process.