### PR TITLE
cron: use minute/hour format like cron instead of current hour/minute format

### DIFF
--- a/scripts/cron.pl
+++ b/scripts/cron.pl
@@ -89,8 +89,8 @@ use vars qw($VERSION %IRSSI);
 
 $VERSION = "1.0";
 %IRSSI = (
-    authors	=> 'Piotr Krukowiecki', 'KindOne',
-    contact	=> 'piotr \at/ krukowiecki /dot\ net', 'KindOne @ libera.chat|oftc|efnet',
+    authors	=> 'Piotr Krukowiecki, KindOne',
+    contact	=> 'piotr \at/ krukowiecki /dot\ net, KindOne @ libera.chat|oftc|efnet',
     name	=> 'cron aka jobs',
     description	=> 'cron implementation, allows to execute commands at given interval/time',
     license	=> 'GNU GPLv2',


### PR DESCRIPTION
Features: 
- Automatically convert "hour minute" format into the correct "minute hour" format used in cron.
- Add version string in ```cron.save``` so the conversion only happens once. 
- Make backup copy ```cron.save.backup``` file of "hour minute" formatted file. 
- ```/jobadd``` now requires "minute hour" format.
- Add columns for ```/jobs``` for easier readability.
- Added WARNING at top of script file since the format has been "hour minute" for over 20+ years and is now different.
- Update version number to 1.0 since these are major changes.


```/jobs``` output:
```
18:20:36 -!- Irssi: Current Jobs:
18:20:36 -!- Irssi: Job# Repeats  Disabled  Server   Minute    Hour   DoM   Month   DoW   Command
18:20:36 -!- Irssi: -----------------------------------------------------------------------------
18:20:36 -!- Irssi: 0)   *        No                 10        18     *     *       *     /echo It is 18:10:00
18:20:36 -!- Irssi: 1)   *        No                 10        *      *     *       *     /echo 10 minutes
18:20:36 -!- Irssi: 2)   *        No                 8         *      *     *       *     /echo 8 minutes
18:20:36 -!- Irssi: 3)   *        No                 9         *      *     *       *     /echo 9 minutes
18:20:36 -!- Irssi: 4)   *        No        foobar   20        *      *     *       *     /echo 20 minutes
18:20:36 -!- Irssi: 5)   4        No        foobar   20        *      *     *       *     /echo 20 minutes
18:20:36 -!- Irssi: 6)   4        No        foobar   11        *      *     *       *     /echo 11 minutes
18:20:36 -!- Irssi: 7)   *        No        foobar   45        17     *     *       *     /echo This will be executed at 17:45
18:20:36 -!- Irssi: 8)   5        No        foobar   45        17     *     *       *     /echo The same as above but only 5 times
18:20:36 -!- Irssi: 9)   *        No        foobar   05        *      *     *       *     /echo Execute this every hour 5 minutes after the hour
18:20:36 -!- Irssi: 10)  *        No        foobar   0         */6    *     *       *     /echo Execute at 0:0, 6:0, 12:0, 18:0
18:20:36 -!- Irssi: 11)  *        No        foobar   */30,45   *      *     *       *     /echo Execute every hour at 00, 30, 45 minute
18:20:36 -!- Irssi: 12)  *        No        foobar   1-15/5    *      *     *       *     /echo at 1,6,11
```

Some testing for the upgrade:

```cron.save``` before upgrade
```
-server  18 10 * * * /echo It is 18:10:00
-server  * 10 * * * /echo 10 minutes
-server  * 8 * * * /echo 8 minutes
-server  * 9 * * * /echo 9 minutes
-server foobar * 20 * * * /echo 20 minutes
-4 -server foobar * 20 * * * /echo 20 minutes
-4 -server foobar * 11 * * * /echo 11 minutes
-server foobar 17 45 * * * /echo This will be executed at 17:45
-5 -server foobar 17 45 * * * /echo The same as above but only 5 times
-server foobar * 05 * * * /echo Execute this every hour 5 minutes after the hour
-server foobar */6 0 * * * /echo Execute at 0:0, 6:0, 12:0, 18:0
-server foobar * */30,45 * * * /echo Execute every hour at 00, 30, 45 minute
-server foobar * 1-15/5 * * * /echo at 1,6,11
```

```cron.save``` after upgrade
```
# cron file version 1.0
-server  10 18 * * * /echo It is 18:10:00
-server  10 * * * * /echo 10 minutes
-server  8 * * * * /echo 8 minutes
-server  9 * * * * /echo 9 minutes
-server foobar 20 * * * * /echo 20 minutes
-4 -server foobar 20 * * * * /echo 20 minutes
-4 -server foobar 11 * * * * /echo 11 minutes
-server foobar 45 17 * * * /echo This will be executed at 17:45
-5 -server foobar 45 17 * * * /echo The same as above but only 5 times
-server foobar 05 * * * * /echo Execute this every hour 5 minutes after the hour
-server foobar 0 */6 * * * /echo Execute at 0:0, 6:0, 12:0, 18:0
-server foobar */30,45 * * * * /echo Execute every hour at 00, 30, 45 minute
-server foobar 1-15/5 * * * * /echo at 1,6,11
```

